### PR TITLE
Feature/impl item

### DIFF
--- a/Source/SpartaDivers/Private/Item/AttachmentBase.cpp
+++ b/Source/SpartaDivers/Private/Item/AttachmentBase.cpp
@@ -3,3 +3,11 @@
 
 #include "Item/AttachmentBase.h"
 
+UAttachmentBase::UAttachmentBase()
+{
+	ItemType = EItemType::Attachment;
+}
+
+void UAttachmentBase::ApplyAttachmentEffect(UGunBase* InGun)
+{
+}

--- a/Source/SpartaDivers/Private/Item/ConsumableBase.cpp
+++ b/Source/SpartaDivers/Private/Item/ConsumableBase.cpp
@@ -3,3 +3,11 @@
 
 #include "Item/ConsumableBase.h"
 
+UConsumableBase::UConsumableBase()
+{
+	ItemType = EItemType::Consumable;
+}
+
+void UConsumableBase::ApplyConsumableEffect(APlayerCharacter* InPlayerCharacter)
+{
+}

--- a/Source/SpartaDivers/Private/Item/ItemBase.cpp
+++ b/Source/SpartaDivers/Private/Item/ItemBase.cpp
@@ -3,3 +3,6 @@
 
 #include "Item/ItemBase.h"
 
+UItemBase::UItemBase()
+{
+}

--- a/Source/SpartaDivers/Public/Item/AttachmentBase.h
+++ b/Source/SpartaDivers/Public/Item/AttachmentBase.h
@@ -6,6 +6,8 @@
 #include "Item/ItemBase.h"
 #include "AttachmentBase.generated.h"
 
+class UGunBase;
+
 /**
  * 
  */
@@ -14,4 +16,8 @@ class SPARTADIVERS_API UAttachmentBase : public UItemBase
 {
 	GENERATED_BODY()
 	
+public:
+	UAttachmentBase();
+
+	virtual void ApplyAttachmentEffect(UGunBase* InGun);
 };

--- a/Source/SpartaDivers/Public/Item/AttachmentBase.h
+++ b/Source/SpartaDivers/Public/Item/AttachmentBase.h
@@ -8,6 +8,16 @@
 
 class UGunBase;
 
+UENUM()
+enum class EAttachmentType : uint8
+{
+	Scope,
+	Muzzle,
+	Magazine,
+	Stock,
+	Grip
+};
+
 /**
  * 
  */
@@ -20,4 +30,10 @@ public:
 	UAttachmentBase();
 
 	virtual void ApplyAttachmentEffect(UGunBase* InGun);
+
+	FORCEINLINE const EAttachmentType GetAttachmentType() const { return AttachmentType; }
+
+protected:
+	UPROPERTY(EditDefaultsOnly)
+	EAttachmentType AttachmentType;
 };

--- a/Source/SpartaDivers/Public/Item/ConsumableBase.h
+++ b/Source/SpartaDivers/Public/Item/ConsumableBase.h
@@ -6,6 +6,8 @@
 #include "Item/ItemBase.h"
 #include "ConsumableBase.generated.h"
 
+class APlayerCharacter;
+
 /**
  * 
  */
@@ -14,4 +16,8 @@ class SPARTADIVERS_API UConsumableBase : public UItemBase
 {
 	GENERATED_BODY()
 	
+public:
+	UConsumableBase();
+
+	virtual void ApplyConsumableEffect(APlayerCharacter* InPlayerCharacter);
 };

--- a/Source/SpartaDivers/Public/Item/ItemBase.h
+++ b/Source/SpartaDivers/Public/Item/ItemBase.h
@@ -6,6 +6,16 @@
 #include "UObject/NoExportTypes.h"
 #include "ItemBase.generated.h"
 
+class UTexture2D;
+
+UENUM()
+enum class EItemType : uint8
+{
+	Gun,
+	Attachment,
+	Consumable
+};
+
 /**
  * 
  */
@@ -13,5 +23,17 @@ UCLASS()
 class SPARTADIVERS_API UItemBase : public UObject
 {
 	GENERATED_BODY()
+
+public:
+	UItemBase();
+
+	FORCEINLINE const UTexture2D* GetIconImage() const { return IconImage; }
+	FORCEINLINE const EItemType GetItemType() const { return ItemType; }
 	
+protected:
+	UPROPERTY(EditDefaultsOnly)
+	UTexture2D* IconImage;
+
+	UPROPERTY(VisibleAnywhere)
+	EItemType ItemType;
 };


### PR DESCRIPTION
아이템 베이스에 아이템 아이콘과 아이템 타입을 만들었습니다.

소비템에는 플레이어캐릭터, 부착물에는 총 배이스를 넘겨서 효과를 적용시키는 함수를 만들었습니다.
각각 스테이터스가 생기면 구현하겠습니다.

부착물에도 Scope, Muzzle, Magazine, Stock, Grip 다섯개의 타입을 만들었습니다. 나중에 총마다 부착물 슬롯을 만들때 필요할 것 같아서 만들었습니다. 자식클래스로 파서 구분할 수 있겠지만
합의된 내용도 아니고 나중에 수정될 여지가 큰거 같아서 Enum형으로 만들었습니다.