### PR TITLE
총기 발사 및 재장전 관련 예외 처리

### DIFF
--- a/Source/SpartaDivers/Private/Item/Weapons/AssaultRifle.cpp
+++ b/Source/SpartaDivers/Private/Item/Weapons/AssaultRifle.cpp
@@ -14,7 +14,7 @@ UAssaultRifle::UAssaultRifle()
     FireRate = 0.1f;
     MaxAmmo = 30;
     CurAmmo = MaxAmmo;
-    ReloadTime = 2.0f;
+    ReloadTime = 1.5f;
 
     CurRecoil = 0.1f;
     MaxRecoil = 1.1f;

--- a/Source/SpartaDivers/Private/PlayerCharacter.cpp
+++ b/Source/SpartaDivers/Private/PlayerCharacter.cpp
@@ -197,7 +197,7 @@ void APlayerCharacter::StopSprint(const FInputActionValue& value)
 
 void APlayerCharacter::Fire(const FInputActionValue& value)
 {
-	if (EquippedGun)
+	if (EquippedGun && bIsReloading == false && EquippedGun->CurAmmo > 0 && GetCharacterMovement()->MaxWalkSpeed == MoveSpeed)
 	{
 		EquippedGun->Fire();
 		AnimInstance = GetMesh()->GetAnimInstance();
@@ -207,12 +207,19 @@ void APlayerCharacter::Fire(const FInputActionValue& value)
 
 void APlayerCharacter::Reload(const FInputActionValue& value)
 {
-	if (EquippedGun)
+	if (EquippedGun && bIsReloading == false)
 	{
-		EquippedGun->Reload();
+		bIsReloading = true;
+		GetWorld()->GetTimerManager().SetTimer(ReloadTimerHandle, this, &APlayerCharacter::FinishReload, EquippedGun->ReloadTime, false);
+
 		AnimInstance = GetMesh()->GetAnimInstance();
 		AnimInstance->Montage_Play(ReloadMontage);
 	}
 }
 
+void APlayerCharacter::FinishReload()
+{
+	EquippedGun->Reload();
 
+	bIsReloading = false;
+}

--- a/Source/SpartaDivers/Public/PlayerCharacter.h
+++ b/Source/SpartaDivers/Public/PlayerCharacter.h
@@ -39,6 +39,9 @@ protected:
 	UPROPERTY(EditAnywhere)
 	UAnimMontage* ReloadMontage;
 
+	bool bIsReloading = false;
+	FTimerHandle ReloadTimerHandle;
+
 public:	
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
@@ -69,4 +72,7 @@ public:
 	
 	UFUNCTION()
 	void Reload(const FInputActionValue& value);
+
+	UFUNCTION()
+	void FinishReload();
 };


### PR DESCRIPTION
1. 캐릭터가 앞을 바라보고 달리는 상태에서 총을 쏘면 애니메이션이 이상해서 달리는 상태에선 총기 발사가 안 되도록 처리
2. 총알이 없을 시 발사가 안 되도록 처리
3. 재장전 중에는 총알 발사 및 다시 재장전하는 로직이 실행되지 않도록 처리
4. 현재 총알 장전 애니메이션이 약 1.5초인 것 같아서 해당 부분 AR 변수값에 반영