### PR TITLE
Imple ProtoLevel

### DIFF
--- a/Content/_Blueprint/BP_MissionStartTrigger.uasset
+++ b/Content/_Blueprint/BP_MissionStartTrigger.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7366e4ac9e9c7adb468f4964c883bc43f2f9893f3c6ae849b6c8caa71ef2eb23
-size 56896
+oid sha256:019d267bcc51ede8d2340fb7675dfbb75ff690d3c03abf1d159e146e96034453
+size 55771

--- a/Content/_Dev/ProtoLevel.umap
+++ b/Content/_Dev/ProtoLevel.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77b16c783e2bd9eaff1ae4e69fb7890ff0cedc9c262bc1a2a295ff5702eeb4e6
+size 466473

--- a/Content/_Framework/MissionDataTable/DefaultMissionData.uasset
+++ b/Content/_Framework/MissionDataTable/DefaultMissionData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28b1dea5712b2c20191a512fdd5f872ac3a37e9345d858a0c5d7cc1dacd306db
-size 3339
+oid sha256:3e253882df81d810d53b578d46a1222f4e149acef4643b180479e55ca54b265f
+size 3495

--- a/Content/_Framework/SpawnDataTable/DefaultEnemySpawnData.uasset
+++ b/Content/_Framework/SpawnDataTable/DefaultEnemySpawnData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57aaef358ddc47f055e590670a31c977fb35d0c419341e2d0f79fed2b09d905d
-size 2855
+oid sha256:b28720af56ae9ddd5b126392a35689cb85ed72886d4c5bc39bd3c46b3d030d51
+size 2844

--- a/Content/_Framework/SpawnDataTable/DefaultEnemySpawnData1.uasset
+++ b/Content/_Framework/SpawnDataTable/DefaultEnemySpawnData1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88159724dd69ee61caab095629c7e5100981cd90717a30c4cf6465a3080c9e4e
+size 2849

--- a/Content/_Level/TestLevel.umap
+++ b/Content/_Level/TestLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:097823e955ef5bb8aae054c56c5ebd75bd2230a74a46288a550e6bcb853e8107
-size 112970
+oid sha256:ef0e2b559770c78bc7eeba0cd46adf5f8c9efc3e628a7cd84b69eead25f0fdd6
+size 110620

--- a/Source/SpartaDivers/Private/Item/Weapons/AssaultRifle.cpp
+++ b/Source/SpartaDivers/Private/Item/Weapons/AssaultRifle.cpp
@@ -19,6 +19,8 @@ UAssaultRifle::UAssaultRifle()
 
     CurRecoil = 0.1f;
     MaxRecoil = 1.1f;
+
+    bOnInfiniteBullet = false;
 }
 
 void UAssaultRifle::Fire()
@@ -27,6 +29,11 @@ void UAssaultRifle::Fire()
     {
         CurAmmo--;
         bCanFire = false;
+        // for CheatManager::InfiniteBullet
+        if (bOnInfiniteBullet)
+        {
+            CurAmmo++;
+        }
 
         UE_LOG(LogTemp, Warning, TEXT("AssaultRifle fired! Ammo: %d/%d"), CurAmmo, MaxAmmo);
 

--- a/Source/SpartaDivers/Private/MissionManager.cpp
+++ b/Source/SpartaDivers/Private/MissionManager.cpp
@@ -4,6 +4,7 @@
 #include "MyGameState.h"
 #include "PlayerCharacter.h"
 #include "Components/BoxComponent.h"
+#include "Components/StatusContainerComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "MissionStartTrigger.h"
 #include "SDEnemyBase.h"
@@ -69,35 +70,57 @@ void AMissionManager::StartMission()
 		MyGameState->UpdateHUD();
 	}
 
-	if (MissionStartTrigger)
-	{
-		MissionStartTrigger->DeactivateTrigger();
-	}
-
 	if (AllMissions.IsValidIndex(CurrentMissionIndex))
 	{
 		bIsPlayerOnMission = true;
 		CurrentMissionData = *AllMissions[CurrentMissionIndex];
 		UE_LOG(LogTemp, Warning, TEXT("Mission %d started: %s"), CurrentMissionIndex, *UEnum::GetValueAsString(CurrentMissionData.MissionType));
+
 		switch (CurrentMissionData.MissionType)
 		{
 		case EMissionType::Eliminate:
 		{
 			SpawnedEnemyCount = 0;
 			KilledEnemyCount = 0;
+
+			TArray<AActor*> FoundAlreadySpawnedEnemies;
+			UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASDEnemyBase::StaticClass(), FoundAlreadySpawnedEnemies);
+			for (AActor* Enemy : FoundAlreadySpawnedEnemies)
+			{
+				if (Enemy->ActorHasTag(CurrentMissionData.MissionName))
+				{
+					SpawnedEnemyCount++;
+				}
+			}
+			UE_LOG(LogTemp, Warning, TEXT("Already SpawnedEnemyCount : %d"), SpawnedEnemyCount);
+
 			SpawnEnemy();
-			// Check When Enemy Dead
+			TArray<AActor*> FoundNewlySpawnedEnemies;
+			UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASDEnemyBase::StaticClass(), FoundNewlySpawnedEnemies);
+			for (AActor* Enemy : FoundNewlySpawnedEnemies)
+			{
+				if (Enemy->ActorHasTag(CurrentMissionData.MissionName))
+				{
+					SpawnedEnemyCount++;
+					UE_LOG(LogTemp, Warning, TEXT("Newly SpawnedEnemyCount : %d"), SpawnedEnemyCount);
+				}
+			}
 			break;
 		}
 		case EMissionType::Survive:
 		{
-			SpawnEnemy();
-			/*GetWorld()->GetTimerManager().SetTimer(
+			GetWorld()->GetTimerManager().SetTimer(
+				SpawnTimerHandle,
+				this,
+				&AMissionManager::SpawnEnemy,
+				1.0f,
+				true);
+			GetWorld()->GetTimerManager().SetTimer(
 				SurvivalTimerHandle,
 				this,
 				&AMissionManager::CheckMissionCompletion,
 				CurrentMissionData.SurviveTime,
-				false);*/
+				false);
 			break;
 		}
 		case EMissionType::Capture:
@@ -123,8 +146,11 @@ void AMissionManager::StartMission()
 
 void AMissionManager::CompleteMission()
 {
-	UE_LOG(LogTemp, Warning, TEXT("Mission %d Success!"), CurrentMissionIndex);
+	// Stop spawning
+	GetWorld()->GetTimerManager().ClearTimer(SpawnTimerHandle);
+
 	bIsPlayerOnMission = false;
+	UE_LOG(LogTemp, Warning, TEXT("Mission %d Success!"), CurrentMissionIndex);
 
 	if (AMyGameState* MyGameState = GetWorld()->GetGameState<AMyGameState>())
 	{
@@ -133,7 +159,7 @@ void AMissionManager::CompleteMission()
 			MyGameState->AddScore(CurrentMissionData.ScoreReward);
 		}
 	}
-	
+
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AMissionStartTrigger::StaticClass(), FoundMissionStartTriggers);
 	for (AActor* FoundMissionStartTrigger : FoundMissionStartTriggers)
 	{
@@ -145,7 +171,7 @@ void AMissionManager::CompleteMission()
 		}
 	}
 
-	DestroyAllEnemies();
+	DestroyEnemiesInCurrentMission(CurrentMissionIndex);
 
 	CurrentMissionIndex++;
 }
@@ -200,7 +226,7 @@ void AMissionManager::CheckMissionCompletion()
 		if (PlayerController)
 		{
 			APlayerCharacter* Player = Cast<APlayerCharacter>(PlayerController->GetPawn());
-			if (1/*플레이어의 체력이 0보다 크면*/)
+			if (Player->GetStatusContainerComponent()->GetCurHealth() >= 0)
 			{
 				CompleteMission();
 			}
@@ -222,7 +248,7 @@ void AMissionManager::CheckMissionCompletion()
 		if (PlayerController)
 		{
 			APlayerCharacter* Player = Cast<APlayerCharacter>(PlayerController->GetPawn());
-			if (1/*플레이어의 체력이 0보다 크면*/)
+			if (Player->GetStatusContainerComponent()->GetCurHealth() >= 0)
 			{
 				CompleteMission();
 			}
@@ -236,7 +262,7 @@ void AMissionManager::CheckMissionCompletion()
 
 void AMissionManager::SpawnEnemy()
 {
-	// 게임 내의 모든 SpawnVolume을 찾음
+	// Finds all SpawnVolumes in the game
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASD_SpawnVolume::StaticClass(), FoundVolumes);
 
 	if (FoundVolumes.Num() > 0 && SpawnDataTables.IsValidIndex(CurrentMissionIndex))
@@ -256,18 +282,17 @@ void AMissionManager::SpawnEnemy()
 			}
 		}
 
-		// 적절한 SpawnVolume이 있는 경우 적 소환
+		// Spawn enemies if the appropriate SpawnVolume exists
 		if (MatchingVolumes.Num() > 0)
 		{
+			ASD_SpawnVolume* SelectedVolume = MatchingVolumes[FMath::RandRange(0, MatchingVolumes.Num() - 1)];
+			SelectedVolume->SetCurrentSpawnDataTable(SpawnDataTables[CurrentMissionIndex]);
 			for (int32 i = 0; i < EnemiesToSpawn; i++)
 			{
-				ASD_SpawnVolume* SelectedVolume = MatchingVolumes[FMath::RandRange(0, MatchingVolumes.Num() - 1)];
+				SelectedVolume = MatchingVolumes[FMath::RandRange(0, MatchingVolumes.Num() - 1)];
 				if (SelectedVolume)
 				{
-					SelectedVolume->SetCurrentSpawnDataTable(SpawnDataTables[CurrentMissionIndex]);
 					SelectedVolume->SpawnRandomEnemy(CurrentMissionIndex);
-
-					UE_LOG(LogTemp, Warning, TEXT("Enemy Spawned from Selected Volume"));
 				}
 			}
 		}
@@ -278,14 +303,14 @@ void AMissionManager::SpawnEnemy()
 	}
 }
 
-void AMissionManager::DestroyAllEnemies()
+void AMissionManager::DestroyEnemiesInCurrentMission(int MissionIndex)
 {
 	TArray<AActor*> FoundEnemies;
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASDEnemyBase::StaticClass(), FoundEnemies);
 
 	for (AActor* Enemy : FoundEnemies)
 	{
-		if (Enemy)
+		if (Enemy->ActorHasTag(CurrentMissionData.MissionName))
 		{
 			Enemy->Destroy();
 		}

--- a/Source/SpartaDivers/Private/MissionStartTrigger.cpp
+++ b/Source/SpartaDivers/Private/MissionStartTrigger.cpp
@@ -47,6 +47,7 @@ void AMissionStartTrigger::DeactivateTrigger()
 
 	SetActorHiddenInGame(true);
 	SetActorEnableCollision(false);
+	Destroy();
 }
 
 void AMissionStartTrigger::OnInteracted()

--- a/Source/SpartaDivers/Private/PlayerCharacter.cpp
+++ b/Source/SpartaDivers/Private/PlayerCharacter.cpp
@@ -51,6 +51,8 @@ void APlayerCharacter::BeginPlay()
 	//}
 
 	EquippedGun = NewObject<UAssaultRifle>(this, UAssaultRifle::StaticClass());
+
+	this->Tags.Add(TEXT("Player"));
 }
 
 void APlayerCharacter::Tick(float DeltaTime)

--- a/Source/SpartaDivers/Private/SDCheatManager.cpp
+++ b/Source/SpartaDivers/Private/SDCheatManager.cpp
@@ -3,6 +3,8 @@
 #include "SDCheatManager.h"
 #include "MyGameState.h"
 #include "PlayerCharacter.h"
+#include "Item/GunBase.h"
+#include "Item/Weapons/AssaultRifle.h"
 #include "SDEnemyBase.h"
 #include "MissionManager.h"
 #include "Kismet/GameplayStatics.h"
@@ -16,13 +18,22 @@ void USDCheatManager::GodMode()
     }
 }
 
+void USDCheatManager::SDKillMe()
+{
+    if (APlayerCharacter* Player = Cast<APlayerCharacter>(GetOuterAPlayerController()->GetPawn()))
+    {
+        Player->OnDeath();
+        UE_LOG(LogTemp, Warning, TEXT("Player Dead By CheatManager!"));
+    }
+}
+
 void USDCheatManager::SDKillAE()
 {
     AMissionManager* MissionManager = Cast<AMissionManager>(UGameplayStatics::GetActorOfClass(GetWorld(), AMissionManager::StaticClass()));
 
     if (MissionManager)
     {
-        MissionManager->DestroyAllEnemies();
+        MissionManager->DestroyEnemiesInCurrentMission(MissionManager->CurrentMissionIndex);
         UE_LOG(LogTemp, Warning, TEXT("Cheat activated: Alle Enemies Destoyed!"));
     }
 }
@@ -50,7 +61,7 @@ void USDCheatManager::SDMStart()
 
 void USDCheatManager::SDMComple()
 {
-    // 현재 월드에서 AMissionManager 찾기
+    // Find the AMissionManager in the current world
     AMissionManager* MissionManager = Cast<AMissionManager>(UGameplayStatics::GetActorOfClass(GetWorld(), AMissionManager::StaticClass()));
 
     if (MissionManager)
@@ -66,5 +77,25 @@ void USDCheatManager::SDMComple()
 
 void USDCheatManager::SDInfi()
 {
-    // 총알무한
+    // Infinite Bullet
+    if (APlayerCharacter* Player = Cast<APlayerCharacter>(GetOuterAPlayerController()->GetPawn()))
+    {
+        if (Player)
+        {
+            UAssaultRifle* AssaultRifle = Cast<UAssaultRifle>(Player->GetEquippedGun());
+            AssaultRifle->bOnInfiniteBullet = true;
+        }
+    }
+}
+
+void USDCheatManager::SDADamage(float NewDamage)
+{
+    if (APlayerCharacter* Player = Cast<APlayerCharacter>(GetOuterAPlayerController()->GetPawn()))
+    {
+        if (Player)
+        {
+            UAssaultRifle* AssaultRifle = Cast<UAssaultRifle>(Player->GetEquippedGun());
+            AssaultRifle->Damage = NewDamage;
+        }
+    }
 }

--- a/Source/SpartaDivers/Private/SDEnemyBase.cpp
+++ b/Source/SpartaDivers/Private/SDEnemyBase.cpp
@@ -2,6 +2,7 @@
 
 #include "SDEnemyBase.h"
 #include "SDAIController.h"
+#include "MissionManager.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Item/DropItem.h"
@@ -60,6 +61,15 @@ void ASDEnemyBase::OnDeath()
 	OnDropItem();
 
 	Super::OnDeath();
+	AMissionManager* MissionManager = Cast<AMissionManager>(UGameplayStatics::GetActorOfClass(GetWorld(), AMissionManager::StaticClass()));
+	if (MissionManager && MissionManager->CurrentMissionData.MissionType == EMissionType::Eliminate)
+	{
+		MissionManager->KilledEnemyCount++;
+		UE_LOG(LogTemp, Warning, TEXT("KilledEnemyCount : %d"), MissionManager->KilledEnemyCount);
+		MissionManager->CheckMissionCompletion();
+	}
+
+	Destroy();
 }
 
 void ASDEnemyBase::OnDropItem()

--- a/Source/SpartaDivers/Private/SD_SpawnVolume.cpp
+++ b/Source/SpartaDivers/Private/SD_SpawnVolume.cpp
@@ -2,7 +2,8 @@
 
 #include "SD_SpawnVolume.h"
 #include "Components/BoxComponent.h"
-
+#include "MissionManager.h"
+#include "Kismet/GameplayStatics.h"
 
 ASD_SpawnVolume::ASD_SpawnVolume()
 {
@@ -33,7 +34,7 @@ FRotator ASD_SpawnVolume::GetRandomRotation() const
 	return RandomRotation;
 }
 
-FEnemySpawnRow* ASD_SpawnVolume::GetRandomObject() const
+FEnemySpawnRow* ASD_SpawnVolume::GetRandomEnemy() const
 {
 	if (!CurrentSpawnDataTable) return nullptr;
 
@@ -74,13 +75,12 @@ EMissionType ASD_SpawnVolume::GetMissionType() const
 
 void ASD_SpawnVolume::SetCurrentSpawnDataTable(UDataTable* SetSpawnDataTable)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SpawnDataTable Changed"));
 	CurrentSpawnDataTable = SetSpawnDataTable;
 }
 
 AActor* ASD_SpawnVolume::SpawnRandomEnemy(int32 MissionIndex)
 {
-	if (FEnemySpawnRow* SelectedRow = GetRandomObject())
+	if (FEnemySpawnRow* SelectedRow = GetRandomEnemy())
 	{
 		if (UClass* ActualClass = SelectedRow->EnemyClass.Get())
 		{
@@ -100,6 +100,18 @@ AActor* ASD_SpawnVolume::SpawnEnemy(TSubclassOf<AActor> EnemyClass, int32 Missio
 		GetRandomPointInVolume(MissionIndex),
 		GetRandomRotation()
 	);
+	// Add MissionName Tag
+	if (SpawnedActor)
+	{
+		AMissionManager* MissionManager = Cast<AMissionManager>(UGameplayStatics::GetActorOfClass(GetWorld(), AMissionManager::StaticClass()));
+		if (MissionManager)
+		{
+			if (!SpawnedActor->Tags.Contains(MissionManager->CurrentMissionData.MissionName))
+			{
+				SpawnedActor->Tags.Add(MissionManager->CurrentMissionData.MissionName);
+			}
+		}
+	}
 
 	return SpawnedActor;
 }

--- a/Source/SpartaDivers/Public/Item/Weapons/AssaultRifle.h
+++ b/Source/SpartaDivers/Public/Item/Weapons/AssaultRifle.h
@@ -23,4 +23,6 @@ public:
 
 	UFUNCTION(BlueprintCallable,Category = "Gun|Actions")
 	void PerformHitScan();
+
+	bool bOnInfiniteBullet;
 };

--- a/Source/SpartaDivers/Public/MissionDataRow.h
+++ b/Source/SpartaDivers/Public/MissionDataRow.h
@@ -24,6 +24,9 @@ public:
     // Type of Mission
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     EMissionType MissionType;
+    // FName of MissionType
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FName MissionName;
     // Score
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     int32 ScoreReward;

--- a/Source/SpartaDivers/Public/MissionManager.h
+++ b/Source/SpartaDivers/Public/MissionManager.h
@@ -18,21 +18,23 @@ class SPARTADIVERS_API AMissionManager : public AActor
 public:
 	AMissionManager();
 
+	// Spawn TimerHandle
+	FTimerHandle SpawnTimerHandle;
 	// Survive TimerHandle
 	FTimerHandle SurvivalTimerHandle;
 	// RestTime before next Mission
 	FTimerHandle NextMissionTimerHandle;
 
 	// Enemy SpawnVolumes
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spawning")
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Spawning")
 	TArray<AActor*> FoundVolumes;
 	// Enemy Spawn DataTable
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spawning")
 	TArray<UDataTable*> SpawnDataTables;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MissionTrigger")
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "MissionTrigger")
 	TArray<AActor*> FoundMissionStartTriggers;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MissionTrigger")
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "MissionTrigger")
 	AMissionStartTrigger* MissionStartTrigger;
 
 	// Mission DataTable
@@ -56,8 +58,11 @@ public:
 	void StartMission();
 	UFUNCTION(BlueprintCallable, Category = "Mission")
 	void CompleteMission();
+	UFUNCTION(BlueprintCallable, Category = "Mission")
+	void CheckMissionCompletion();
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mission")
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mission")
 	bool bIsPlayerOnMission;
 
 	// Spawn enemies based on chance in SpawnDataTables
@@ -65,7 +70,7 @@ public:
 	void SpawnEnemy();
 	// Destoy all enemies when Complete Mission
 	UFUNCTION(BlueprintCallable, Category = "Spawning")
-	void DestroyAllEnemies();
+	void DestroyEnemiesInCurrentMission(int MissionIndex);
 
 	// ============== Eliminate ==============
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Eliminate")
@@ -77,7 +82,7 @@ public:
 	// ============== Capture ============== 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Capture")
 	float CaptureProgress;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Capture")
 	UBoxComponent* CaptureZone;
 	UFUNCTION()
 	virtual void OnObjectOverlap(
@@ -100,6 +105,5 @@ private:
 	bool bIsPlayerInCaptureZone;
 	/* ======================================== */
 	
-	void CheckMissionCompletion();
 
 };

--- a/Source/SpartaDivers/Public/SDCheatManager.h
+++ b/Source/SpartaDivers/Public/SDCheatManager.h
@@ -16,6 +16,8 @@ public:
     UFUNCTION(Exec)
     void GodMode();
 
+    void SDKillMe();
+
     // Kill All Enemies
     UFUNCTION(Exec)
     void SDKillAE();
@@ -35,6 +37,10 @@ public:
     // Make Bullet Infinite
     UFUNCTION(exec)
     void SDInfi();
+
+    // Change Damage of AssaultRifle
+    UFUNCTION(exec)
+    void SDADamage(float NewDamage);
 
 
 };

--- a/Source/SpartaDivers/Public/SD_SpawnVolume.h
+++ b/Source/SpartaDivers/Public/SD_SpawnVolume.h
@@ -32,7 +32,7 @@ public:
     FRotator GetRandomRotation() const;
     UFUNCTION(BlueprintCallable, Category = "Spawning")
     AActor* SpawnEnemy(TSubclassOf<AActor> EnemyClass, int32 MissionIndex);
-    FEnemySpawnRow* GetRandomObject() const;
+    FEnemySpawnRow* GetRandomEnemy() const;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MissionType")
     EMissionType AssignedMissionType;


### PR DESCRIPTION
Add : Prototype of Main Level

Survive
:미션 성공하기 전이라면 1초마다 EnemyCount만큼 무한으로 스폰하게 했습니다.

MissionStartTrigger 
:MissionStartTrigger가 TriggerDeactivate후 Destoy되도록 수정했습니다.
AMissionManager::DestroyEnemiesInCurrentMission
:Enemy의 태그로 구분해 MissionName을 태그로 갖고있다면 제거되도록 수정했습니다. 이에 따라 SpawnEnemy()호출 시 MissionName을 태그로 추가하도록 수정했고, 미리 맵에 배치하는 적에게 해당하는 MissionName을 추가해야합니다. 
SpawnedEnemyCount와 KilledEnemyCount로직 작성했습니다.

CheatManager
:용이한 테스트를 위해 SDKillMe()치트를 추가했습니다.
용이한 테스트를 위해 SDInfi()치트를 추가했습니다.
용이한 테스트를 위해 SDADamage(float NewDamage)치트를 추가했습니다.